### PR TITLE
Feature/silentmode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Feature: add `silent` configuration option.
+
 ## 0.3.2
 
 * Bug: Make `concurrency: 1` / "serial" mode actually run serially.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
       --concurrency  Parallel processes to use (default: 1)            [number]
   -d, --dry-run      Don't actually produce output bundle              [boolean]
   -r, --report       Generate extended report                          [boolean]
+  -s, --silent       Don't output logs to the console                  [boolean]
   -h, --help         Show help                                         [boolean]
   -v, --version      Show version number                               [boolean]
 ```

--- a/bin/lib/args.js
+++ b/bin/lib/args.js
@@ -65,7 +65,8 @@ const getArgs = async (args) => {
     version: !!argv.version,
     dryRun: !!argv.dryRun,
     concurrency: argv.concurrency,
-    report: argv.report
+    report: argv.report,
+    silent: argv.silent
   };
 
   // Convert config file to full object.

--- a/bin/lib/args.js
+++ b/bin/lib/args.js
@@ -45,10 +45,17 @@ const getArgs = async (args) => {
       describe: "Generate extended report",
       type: "boolean"
     })
+    .option("silent", {
+      alias: "s",
+      describe: "Don't ouput logs to the console",
+      type: "boolean"
+    })
     // Logistical
     .exitProcess(false)
-    .help().alias("help", "h")
-    .version(version).alias("version", "v")
+    .help()
+    .alias("help", "h")
+    .version(version)
+    .alias("version", "v")
     .strict();
 
   // Validate

--- a/bin/trace-pkg.js
+++ b/bin/trace-pkg.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { getArgs } = require("./lib/args");
-const { error } = require("../lib/log");
+const { error, setLoggingOptions } = require("../lib/log");
 const createPackage = require("../lib/actions/package").package;
 
 // ============================================================================
@@ -11,6 +11,7 @@ const createPackage = require("../lib/actions/package").package;
 // ============================================================================
 const cli = async ({ args } = {}) => {
   const { opts } = await getArgs(args);
+  setLoggingOptions(opts);
 
   if (!(opts.help || opts.version)) {
     await createPackage({ opts });

--- a/lib/log.js
+++ b/lib/log.js
@@ -3,13 +3,15 @@
 "use strict";
 
 const { yellow, red } = require("chalk");
-const { debuglog } = require("util");
+const { debuglog: debug } = require("util");
 
 let enabled = true;
 
 const setLoggingOptions = async (opts) => {
   enabled = !opts.silent;
 };
+
+const debuglog = (...args) => enabled && debug(...args);
 
 const log = (...args) => enabled && console.log(...args);
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -7,8 +7,8 @@ const { debuglog: debug } = require("util");
 
 let enabled = true;
 
-const setLoggingOptions = async (opts) => {
-  enabled = !opts.silent;
+const setLoggingOptions = ({ silent }) => {
+  enabled = !silent;
 };
 
 const debuglog = (...args) => enabled && debug(...args);

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,17 +1,26 @@
+/* eslint-disable no-console */
+
 "use strict";
 
 const { yellow, red } = require("chalk");
 const { debuglog } = require("util");
 
-const log = (...args) => console.log(...args); // eslint-disable-line no-console
+let enabled = true;
 
-const warn = (...args) => console.log(yellow("WARN"), ...args); // eslint-disable-line no-console
+const setLoggingOptions = async (opts) => {
+  enabled = !opts.silent;
+};
 
-const error = (...args) => console.error(red("ERROR"), ...args); // eslint-disable-line no-console
+const log = (...args) => enabled && console.log(...args);
+
+const warn = (...args) => enabled && console.log(yellow("WARN"), ...args);
+
+const error = (...args) => enabled && console.error(red("ERROR"), ...args);
 
 module.exports = {
   debuglog,
   log,
   warn,
-  error
+  error,
+  setLoggingOptions
 };

--- a/test/lib/log.spec.js
+++ b/test/lib/log.spec.js
@@ -3,49 +3,49 @@
 /* eslint-disable no-console */
 
 const { setLoggingOptions, error, log, warn } = require("../../lib/log");
-const chai = require("chai");
 const sinon = require("sinon");
-const sinonChai = require("sinon-chai");
-chai.use(sinonChai);
 
 describe("lib/log", () => {
+  let sandbox;
+  let logStub;
+  let errorStub;
   beforeEach(() => {
-    sinon.spy(console, "log");
-    sinon.spy(console, "error");
+    sandbox = sinon.createSandbox();
+    logStub = sandbox.stub(console, "log");
+    errorStub = sandbox.stub(console, "error");
   });
 
   afterEach(() => {
-    console.log.restore();
-    console.error.restore();
+    sandbox.restore();
   });
 
   describe("default options should log", () => {
     it("log should call console.log", () => {
       log();
-      expect(console.log).to.be.called;
+      expect(logStub).to.be.called;
     });
     it("warn should call console.log", () => {
       warn();
-      expect(console.log).to.be.called;
+      expect(logStub).to.be.called;
     });
     it("error should call console.error", () => {
       error();
-      expect(console.error).to.be.called;
+      expect(errorStub).to.be.called;
     });
   });
   describe("silent mode shouldn't log", () => {
     it("log shouldn't call console.log", () => {
       setLoggingOptions({ silent: true });
       log();
-      expect(console.log).to.not.be.called;
+      expect(logStub).to.not.be.called;
     });
     it("warn shouldn't call console.log", () => {
       warn();
-      expect(console.log).to.not.be.called;
+      expect(logStub).to.not.be.called;
     });
     it("error shouldn't call console.error", () => {
       error();
-      expect(console.error).to.not.be.called;
+      expect(logStub).to.not.be.called;
     });
   });
 })

--- a/test/lib/log.spec.js
+++ b/test/lib/log.spec.js
@@ -1,0 +1,52 @@
+"use strict";
+
+/* eslint-disable no-console */
+
+const { setLoggingOptions, error, log, warn } = require("../../lib/log");
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+
+describe("lib/log", () => {
+  beforeEach(() => {
+    sinon.spy(console, "log");
+    sinon.spy(console, "error");
+  });
+
+  afterEach(() => {
+    console.log.restore();
+    console.error.restore();
+  });
+
+  describe("default options should log", () => {
+    it("log should call console.log", () => {
+      log();
+      expect(console.log).to.be.called;
+    });
+    it("warn should call console.log", () => {
+      warn();
+      expect(console.log).to.be.called;
+    });
+    it("error should call console.error", () => {
+      error();
+      expect(console.error).to.be.called;
+    });
+  });
+  describe("silent mode shouldn't log", () => {
+    it("log shouldn't call console.log", () => {
+      setLoggingOptions({ silent: true });
+      log();
+      expect(console.log).to.not.be.called;
+    });
+    it("warn shouldn't call console.log", () => {
+      warn();
+      expect(console.log).to.not.be.called;
+    });
+    it("error shouldn't call console.error", () => {
+      error();
+      expect(console.error).to.not.be.called;
+    });
+  });
+})
+;


### PR DESCRIPTION
This should address issue #12 by setting an enabled flag in the `lib/log.js` folder which is inferred from the `-s` cli flag.

Tests have been added to verify silent mode works for `log`, `warn` and `error` which all use the console methods. The `debuglog` has proven to be a bit harder to test.